### PR TITLE
fix: allow users to pass one url if auth url is the same fo IBM watsonx.ai software auth

### DIFF
--- a/libs/langchain-community/src/utils/ibm.ts
+++ b/libs/langchain-community/src/utils/ibm.ts
@@ -46,7 +46,7 @@ export const authenticateAndSetInstance = ({
   } else if (watsonxAIAuthType === "cp4d") {
     // cp4d auth requires username with either Password of ApiKey but not both.
     if (watsonxAIUsername && (watsonxAIPassword || watsonxAIApikey)) {
-      const watsonxCPDAuthUrl = watsonxAIUrl ? watsonxAIUrl : serviceUrl;
+      const watsonxCPDAuthUrl = watsonxAIUrl ?? serviceUrl;
       return WatsonXAI.newInstance({
         version,
         serviceUrl,

--- a/libs/langchain-community/src/utils/ibm.ts
+++ b/libs/langchain-community/src/utils/ibm.ts
@@ -43,10 +43,12 @@ export const authenticateAndSetInstance = ({
         bearerToken: watsonxAIBearerToken,
       }),
     });
-  } else if (watsonxAIAuthType === "cp4d" && watsonxAIUrl) {
+  } else if (watsonxAIAuthType === "cp4d" ) {
     // cp4d auth requires username with either Password of ApiKey but not both.
     if (watsonxAIUsername && (watsonxAIPassword || watsonxAIApikey)) {
-      const watsonxCPDAuthUrl = watsonxAIUrl.concat("/icp4d-api/v1/authorize");
+      const watsonxCPDAuthUrl = watsonxAIUrl
+        ? watsonxAIUrl.concat("/icp4d-api/v1/authorize")
+        : serviceUrl.concat("/icp4d-api/v1/authorize");
       return WatsonXAI.newInstance({
         version,
         serviceUrl,

--- a/libs/langchain-community/src/utils/ibm.ts
+++ b/libs/langchain-community/src/utils/ibm.ts
@@ -43,7 +43,7 @@ export const authenticateAndSetInstance = ({
         bearerToken: watsonxAIBearerToken,
       }),
     });
-  } else if (watsonxAIAuthType === "cp4d" ) {
+  } else if (watsonxAIAuthType === "cp4d") {
     // cp4d auth requires username with either Password of ApiKey but not both.
     if (watsonxAIUsername && (watsonxAIPassword || watsonxAIApikey)) {
       const watsonxCPDAuthUrl = watsonxAIUrl

--- a/libs/langchain-community/src/utils/ibm.ts
+++ b/libs/langchain-community/src/utils/ibm.ts
@@ -46,9 +46,7 @@ export const authenticateAndSetInstance = ({
   } else if (watsonxAIAuthType === "cp4d") {
     // cp4d auth requires username with either Password of ApiKey but not both.
     if (watsonxAIUsername && (watsonxAIPassword || watsonxAIApikey)) {
-      const watsonxCPDAuthUrl = watsonxAIUrl
-        ? watsonxAIUrl.concat("/icp4d-api/v1/authorize")
-        : serviceUrl.concat("/icp4d-api/v1/authorize");
+      const watsonxCPDAuthUrl = watsonxAIUrl ? watsonxAIUrl : serviceUrl;
       return WatsonXAI.newInstance({
         version,
         serviceUrl,
@@ -56,7 +54,7 @@ export const authenticateAndSetInstance = ({
         authenticator: new CloudPakForDataAuthenticator({
           username: watsonxAIUsername,
           password: watsonxAIPassword,
-          url: watsonxCPDAuthUrl,
+          url: watsonxCPDAuthUrl.concat("/icp4d-api/v1/authorize"),
           apikey: watsonxAIApikey,
           disableSslVerification: disableSSL,
         }),

--- a/libs/langchain-community/src/utils/ibm.ts
+++ b/libs/langchain-community/src/utils/ibm.ts
@@ -50,6 +50,7 @@ export const authenticateAndSetInstance = ({
       return WatsonXAI.newInstance({
         version,
         serviceUrl,
+        disableSslVerification: disableSSL,
         authenticator: new CloudPakForDataAuthenticator({
           username: watsonxAIUsername,
           password: watsonxAIPassword,


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
